### PR TITLE
Toggle display of filter input to none when selected.

### DIFF
--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -299,6 +299,9 @@ export default {
       return !this.$v.value.$invalid;
     },
     filterInput() {
+      if(!this.$refs.countrySelector) {
+        return document.createElement('input');
+      }
       return this.$refs.countrySelector.$el.querySelector('input');
     }
   },

--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -162,7 +162,7 @@ export default {
     };
   },
   mounted() {
-    this.filterInput().setAttribute('autocomplete', 'new-address');
+    this.hideFilterInput();
     // users might need to have access to the validator.
     this.$emit('validator', {validator: this.$v});
   },
@@ -324,6 +324,11 @@ export default {
       }
       return this.$refs.countrySelector.$el.querySelector('input');
     },
+    hideFilterInput() {
+      this.filterInput().setAttribute('autocomplete', 'new-address');
+      this.filterInput().blur();
+      this.filterInput().style.display = 'none';
+    },
     async filterCountries(val, update) {
       this.filterInput().style.display = 'inline-block';
       this.filterInput().focus();
@@ -340,8 +345,7 @@ export default {
     handleSelect() {
       // the default behavior in the beta is to leave the input focused on select.
       this.filter.countries = '';
-      this.filterInput().blur();
-      this.filterInput().style.display = 'none';
+      this.hideFilterInput();
       this.$v.value.addressCountry.$touch();
       if(this.$v.value.addressRegion.$invalid && this.regions) {
         this.$v.value.addressRegion.$reset();

--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -147,6 +147,11 @@ export default {
       type: Object,
       required: false,
       default: () => ([])
+    },
+    // you can pass in a custom validator
+    validator: {
+      type: Object,
+      required: false
     }
   },
   data() {
@@ -160,6 +165,11 @@ export default {
     this.filterInput().setAttribute('autocomplete', 'new-address');
   },
   validations() {
+    // if there is a custom validator use it.
+    if(this.validator) {
+      console.log('using a custom validator');
+      return this.validator;
+    }
     if(this.addressCountryExists) {
       return {
         value: {

--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -163,11 +163,12 @@ export default {
   },
   mounted() {
     this.filterInput().setAttribute('autocomplete', 'new-address');
+    // users might need to have access to the validator.
+    this.$emit('validator', {validator: this.$v});
   },
   validations() {
     // if there is a custom validator use it.
     if(this.validator) {
-      console.log('using a custom validator');
       return this.validator;
     }
     if(this.addressCountryExists) {

--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -304,6 +304,8 @@ export default {
   },
   methods: {
     async filterCountries(val, update) {
+      this.filterInput.style.display = 'inline-block';
+      this.filterInput.focus();
       this.$v.value.addressCountry.$reset();
       this.value.addressCountry = '';
       this.filter.countries = '';
@@ -312,11 +314,13 @@ export default {
       }
       return update(() => {
         this.filter.countries = val.toLowerCase();
-      });      
+      });
     },
     handleSelect() {
       // the default behavior in the beta is to leave the input focused on select.
+      this.filter.countries = '';
       this.filterInput.blur();
+      this.filterInput.style.display = 'none';
       this.$v.value.addressCountry.$touch();
       if(this.$v.value.addressRegion.$invalid && this.regions) {
         this.$v.value.addressRegion.$reset();

--- a/BrAddressForm.vue
+++ b/BrAddressForm.vue
@@ -157,7 +157,7 @@ export default {
     };
   },
   mounted() {
-    this.filterInput.setAttribute('autocomplete', 'new-address');
+    this.filterInput().setAttribute('autocomplete', 'new-address');
   },
   validations() {
     if(this.addressCountryExists) {
@@ -297,18 +297,25 @@ export default {
     },
     valid() {
       return !this.$v.value.$invalid;
-    },
+    }
+  },
+  methods: {
+    /**
+     * filterInput is a method and not computed because it is
+     * not used in the template. Vue does not update computed
+     * properties not used in the template.
+     *
+     * @returns {object} An input object.
+    */
     filterInput() {
       if(!this.$refs.countrySelector) {
         return document.createElement('input');
       }
       return this.$refs.countrySelector.$el.querySelector('input');
-    }
-  },
-  methods: {
+    },
     async filterCountries(val, update) {
-      this.filterInput.style.display = 'inline-block';
-      this.filterInput.focus();
+      this.filterInput().style.display = 'inline-block';
+      this.filterInput().focus();
       this.$v.value.addressCountry.$reset();
       this.value.addressCountry = '';
       this.filter.countries = '';
@@ -322,8 +329,8 @@ export default {
     handleSelect() {
       // the default behavior in the beta is to leave the input focused on select.
       this.filter.countries = '';
-      this.filterInput.blur();
-      this.filterInput.style.display = 'none';
+      this.filterInput().blur();
+      this.filterInput().style.display = 'none';
       this.$v.value.addressCountry.$touch();
       if(this.$v.value.addressRegion.$invalid && this.regions) {
         this.$v.value.addressRegion.$reset();


### PR DESCRIPTION
Solves the weird spacing issue found here:

https://github.com/digitalbazaar/bedrock-vue-create-organization-wizard/pull/5

The issue was on select the input still had text in it resulting in some countries causing a slight bump. We now toggle display: none on select and on filter display: 'inline-block'
Have not noticed any news bugs caused by this, but does further highlight just how bad the q-select filter functionality is in beta.